### PR TITLE
Remove PNG export

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 AllCops:
   TargetRubyVersion: 3.1
+  NewCops: enable
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,3 +18,6 @@ Metrics/ParameterLists:
 
 Metrics/BlockLength:
   Max: 150
+
+Metrics/ClassLength:
+  Max: 500

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,10 @@
 PATH
   remote: .
   specs:
-    qr_forge (1.0)
+    qr_forge (1.1.0)
       base64 (~> 0.3.0)
       nokogiri (~> 1.18)
       rqrcode_core (~> 2.0)
-      vips (~> 8.15)
-      zeitwerk (~> 2.6)
-    qr_forge (1.0.0)
-      base64 (~> 0.3.0)
-      nokogiri (~> 1.18)
-      rqrcode_core (~> 2.0)
-      vips (~> 8.15)
       zeitwerk (~> 2.6)
 
 GEM
@@ -33,7 +26,6 @@ GEM
     date (3.4.1)
     diff-lcs (1.6.2)
     erb (5.0.1)
-    ffi (1.17.2-arm64-darwin)
     io-console (0.8.0)
     irb (1.15.2)
       pp (>= 0.6.0)
@@ -103,8 +95,6 @@ GEM
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
-    vips (8.15.1)
-      ffi (~> 1.12)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.7.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,8 @@ GEM
     mini_mime (1.1.5)
     nokogiri (1.18.8-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.18.8-x86_64-linux-gnu)
+      racc (~> 1.4)
     parallel (1.27.0)
     parser (3.3.8.0)
       ast (~> 2.4.1)
@@ -101,6 +103,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-24
+  x86_64-linux
 
 DEPENDENCIES
   capybara (~> 3.40)

--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,8 @@ RSpec::Core::RakeTask.new(:spec)
 
 require "rubocop/rake_task"
 
-RuboCop::RakeTask.new
+RuboCop::RakeTask.new do |task|
+  task.fail_on_error = false
+end
 
 task default: %i[spec rubocop]

--- a/lib/qr_forge/components/eye_outer/circle.rb
+++ b/lib/qr_forge/components/eye_outer/circle.rb
@@ -23,7 +23,7 @@ module QrForge
             cx: cx,
             cy: cy,
             r: r,
-            'stroke-width': stroke_width,
+            "stroke-width": stroke_width,
             stroke: color,
             fill: "transparent",
             test_id: @test_id

--- a/lib/qr_forge/exporter.rb
+++ b/lib/qr_forge/exporter.rb
@@ -6,13 +6,17 @@ module QrForge
   class Exporter
     def initialize(config:)
       @format = config.dig(:output, :format) || :svg
-      @clean_output = config.dig(:output, :clean_output) != false
     end
 
+    #
+    # Exports the generated QR code in the specified format.
+    # @param svg [String] The generated SVG content of the QR code
+    # @return [String] The exported QR code in the specified format
+    # @raise [RuntimeError] if the format is unsupported
     def export(svg)
       case @format
       when :svg
-        clean_svg(svg)
+        process_svg(svg)
       else
         raise "Unsupported export format: #{@format}"
       end
@@ -21,10 +25,20 @@ module QrForge
     private
 
     #
+    # Performs any last-minute processing on the svg before exporting if applicable
+    # @param [String] svg the preprocessed svg
+    # @return [String] the final svg
+    def process_svg(svg)
+      return svg if ENV["SVG_OUTPUT_MODE"] == "test"
+
+      clean(svg)
+    end
+
+    #
     # Cleans the SVG by removing test_id attributes.
     # @param svg [String] The generated SVG
     # @return [String] The cleaned SVG content
-    def clean_svg(svg)
+    def clean(svg)
       doc = Nokogiri::XML(svg)
       doc.xpath("//@test_id").remove
       doc.to_xml

--- a/lib/qr_forge/forge.rb
+++ b/lib/qr_forge/forge.rb
@@ -20,7 +20,7 @@ module QrForge
     #   - `:qr` - QR code specific settings (e.g., version).
     #   - `:design` - Design specific settings (e.g., colors, shapes).
     #   - `:output` - Export specific settings (e.g., format).
-    # @return [String, StringIO] The SVG or PNG representation of the QR code
+    # @return [String] The SVG or PNG representation of the QR code
     def self.build(data:, type: :url, config: {})
       new(data:, type:, config:).build
     end

--- a/lib/qr_forge/payload.rb
+++ b/lib/qr_forge/payload.rb
@@ -5,7 +5,6 @@ module QrForge
   # Payload is a factory class that builds different types of payloads based on the provided type and data.
   # It will validate the payload data (based on the type) and return a string representation of the payload.
   class Payload
-
     # TODO: Add passkey and sms support and vcard
     PAYLOAD_TYPES = {
       wifi: ::QrForge::Payloads::Wifi,

--- a/lib/qr_forge/payload.rb
+++ b/lib/qr_forge/payload.rb
@@ -6,7 +6,7 @@ module QrForge
   # It will validate the payload data (based on the type) and return a string representation of the payload.
   class Payload
 
-    # TODO: Add passkey and sms support
+    # TODO: Add passkey and sms support and vcard
     PAYLOAD_TYPES = {
       wifi: ::QrForge::Payloads::Wifi,
       plain: ::QrForge::Payloads::PlainText,

--- a/lib/qr_forge/payloads/geo.rb
+++ b/lib/qr_forge/payloads/geo.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-#
+
 module QrForge
   module Payloads
     #

--- a/lib/qr_forge/payloads/phone.rb
+++ b/lib/qr_forge/payloads/phone.rb
@@ -1,4 +1,4 @@
-require 'uri'
+# frozen_string_literal: true
 
 module QrForge
   module Payloads
@@ -6,7 +6,6 @@ module QrForge
     # Represents a telephone payload
     # @example return "https://example.com" or "http://example.com"
     class Phone
-
       def initialize(phone_number)
         @phone_number = phone_number
       end

--- a/lib/qr_forge/payloads/url.rb
+++ b/lib/qr_forge/payloads/url.rb
@@ -1,4 +1,6 @@
-require 'uri'
+# frozen_string_literal: true
+
+require "uri"
 
 module QrForge
   module Payloads
@@ -6,7 +8,6 @@ module QrForge
     # Represents a URL payload
     # @example return "https://example.com" or "http://example.com"
     class Url
-
       def initialize(url)
         @url = url
       end

--- a/lib/qr_forge/qr_data.rb
+++ b/lib/qr_forge/qr_data.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "rqrcode_core/qrcode"
+require "rqrcode_core"
 
 module QrForge
   #
@@ -11,7 +11,7 @@ module QrForge
     attr_reader :modules, :version, :module_count, :quiet_zone
 
     def initialize(text:, version: 10, level: :h)
-      qr = RQRCodeCore::QRCode.new(text, size: version, level: level)
+      qr = ::RQRCodeCore::QRCode.new(text, size: version, level: level)
       @version = qr.version
       @modules = qr.modules.map(&:dup)
       @module_count = @modules.size

--- a/lib/qr_forge/renderer.rb
+++ b/lib/qr_forge/renderer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'nokogiri'
+require "nokogiri"
 
 module QrForge
   #
@@ -46,7 +46,7 @@ module QrForge
       @quiet_zone = 4
       @module_count = qr_data.module_count
       @image = config.dig(:design, :image)
-      @size = config.dig(:output, :size)
+      @size = config.dig(:design, :size)
       @colors = DEFAULT_COLORS.merge(config.dig(:design, :colors) || {})
       @layout = QrForge::Layout.new(qr_data:, has_image: image_present?)
     end

--- a/lib/qr_forge/renderer.rb
+++ b/lib/qr_forge/renderer.rb
@@ -46,7 +46,7 @@ module QrForge
       @quiet_zone = 4
       @module_count = qr_data.module_count
       @image = config.dig(:design, :image)
-      @size = config.dig(:design, :size)
+      @size = config.dig(:output, :size)
       @colors = DEFAULT_COLORS.merge(config.dig(:design, :colors) || {})
       @layout = QrForge::Layout.new(qr_data:, has_image: image_present?)
     end

--- a/lib/qr_forge/renderer.rb
+++ b/lib/qr_forge/renderer.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-require "nokogiri"
-require_relative "layout"
+require 'nokogiri'
 
 module QrForge
   #
@@ -47,8 +46,7 @@ module QrForge
       @quiet_zone = 4
       @module_count = qr_data.module_count
       @image = config.dig(:design, :image)
-      @width = config.dig(:design, :size)
-      @height = config.dig(:design, :size)
+      @size = config.dig(:output, :size)
       @colors = DEFAULT_COLORS.merge(config.dig(:design, :colors) || {})
       @layout = QrForge::Layout.new(qr_data:, has_image: image_present?)
     end
@@ -58,10 +56,11 @@ module QrForge
     def to_svg
       Nokogiri::XML::Builder.new(encoding: "UTF-8") do |xml|
         xml.svg(
-          width: @width || canvas_size,
-          height: @height || canvas_size,
+          width: @size,
+          height: @size,
           xmlns: "http://www.w3.org/2000/svg",
-          viewBox: "0 0 #{canvas_size} #{canvas_size}"
+          viewBox: "0 0 #{canvas_size} #{canvas_size}",
+          shape_rendering: "crispEdges"
         ) do
           draw_background(xml)
           draw_image(xml)
@@ -98,10 +97,10 @@ module QrForge
     def draw_image(xml)
       return unless image_present? && @qr_data.version >= 2
 
-      image_range = @layout.image_area # a Range (row indices) for the image
+      image_range = @layout.image_area # row indices for the image
       size = image_range.size # width/height in modules
 
-      # Convert module coords → SVG coords (including quiet zone)
+      # Convert module coords to SVG coords (including quiet zone)
       x = image_range.first + @quiet_zone
       y = image_range.first + @quiet_zone
 

--- a/qr_forge.gemspec
+++ b/qr_forge.gemspec
@@ -40,4 +40,5 @@ Gem::Specification.new do |spec|
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html
+  spec.metadata["rubygems_mfa_required"] = "true"
 end

--- a/qr_forge.gemspec
+++ b/qr_forge.gemspec
@@ -13,8 +13,6 @@ Gem::Specification.new do |spec|
   spec.license = "MIT"
   spec.required_ruby_version = ">= 3.1.0"
 
-  #spec.metadata["allowed_push_host"] = "TODO: Set to your gem server 'https://example.com'"
-
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/keegankb93/qr_forge"
   spec.metadata["changelog_uri"] = "https://github.com/keegankb93/qr_forge/blob/main/CHANGELOG.md"
@@ -36,7 +34,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "base64", "~> 0.3.0"
   spec.add_dependency "nokogiri", "~> 1.18"
   spec.add_dependency "rqrcode_core", "~> 2.0"
-  spec.add_dependency "vips", "~> 8.15"
   spec.add_dependency "zeitwerk", "~> 2.6"
 
   spec.add_development_dependency "capybara", "~> 3.40"

--- a/spec/components_spec.rb
+++ b/spec/components_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe QrForge, type: :feature do
         config: {
           qr: { version: 10 },
           components: {
-            outer_eye: ::QrForge::Components::EyeOuter::Square
+            outer_eye: QrForge::Components::EyeOuter::Square
           }
         }
       )
@@ -24,7 +24,7 @@ RSpec.describe QrForge, type: :feature do
         config: {
           qr: { version: 10 },
           components: {
-            outer_eye: ::QrForge::Components::EyeOuter::Circle
+            outer_eye: QrForge::Components::EyeOuter::Circle
           }
         }
       )
@@ -42,7 +42,7 @@ RSpec.describe QrForge, type: :feature do
         config: {
           qr: { version: 10 },
           components: {
-            inner_eye: ::QrForge::Components::EyeInner::Square
+            inner_eye: QrForge::Components::EyeInner::Square
           }
         }
       )
@@ -58,7 +58,7 @@ RSpec.describe QrForge, type: :feature do
         config: {
           qr: { version: 10 },
           components: {
-            inner_eye: ::QrForge::Components::EyeInner::Circle
+            inner_eye: QrForge::Components::EyeInner::Circle
           }
         }
       )
@@ -76,7 +76,7 @@ RSpec.describe QrForge, type: :feature do
         config: {
           qr: { version: 10 },
           components: {
-            module: ::QrForge::Components::Module::Square
+            module: QrForge::Components::Module::Square
           }
         }
       )
@@ -92,7 +92,7 @@ RSpec.describe QrForge, type: :feature do
         config: {
           qr: { version: 10 },
           components: {
-            module: ::QrForge::Components::Module::Circle
+            module: QrForge::Components::Module::Circle
           }
         }
       )

--- a/spec/design_spec.rb
+++ b/spec/design_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe QrForge, type: :feature do
       data: "https://example.com",
       config: {
         qr: { version: 10 },
-        design: {
+        output: {
           size: 200
         }
       }

--- a/spec/design_spec.rb
+++ b/spec/design_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe QrForge, type: :feature do
-
   it "colors the outer_eye blue" do
     svg = QrForge::Forge.build(
       data: "https://example.com",

--- a/spec/payload_spec.rb
+++ b/spec/payload_spec.rb
@@ -4,106 +4,106 @@ RSpec.describe QrForge do
   context "when building payloads" do
     it "raises an error for nil data" do
       expect do
-        ::QrForge::Payload.build(data: nil, type: :plain)
+        QrForge::Payload.build(data: nil, type: :plain)
       end.to raise_error(ArgumentError, "Invalid data type: NilClass. Expected Hash or String.")
     end
 
     it "raises an error for invalid data type" do
       expect do
-        ::QrForge::Payload.build(data: 12_345, type: :plain)
+        QrForge::Payload.build(data: 12_345, type: :plain)
       end.to raise_error(ArgumentError, "Invalid data type: Integer. Expected Hash or String.")
     end
 
     it "does not raise an error when string" do
       expect do
-        ::QrForge::Payload.build(data: "Valid Data", type: :plain)
+        QrForge::Payload.build(data: "Valid Data", type: :plain)
       end.not_to raise_error
     end
 
     it "does not raise an error when hash" do
       expect do
-        ::QrForge::Payload.build(data: { latitude: 74, longitude: 85 }, type: :geo)
+        QrForge::Payload.build(data: { latitude: 74, longitude: 85 }, type: :geo)
       end.not_to raise_error
     end
   end
 
   context "when plain text" do
     it "validates and returns a valid payload" do
-      payload = ::QrForge::Payload.build(data: "Hello, World!", type: :plain)
+      payload = QrForge::Payload.build(data: "Hello, World!", type: :plain)
       expect(payload.to_s).to eq("Hello, World!")
     end
 
     it "raises an error for empty string" do
       expect do
-        ::QrForge::Payload.build(data: "", type: :plain)
+        QrForge::Payload.build(data: "", type: :plain)
       end.to raise_error(QrForge::Payloads::PayloadValidationError, "String cannot be empty")
     end
   end
 
   context "when phone number" do
     it "validates and returns a valid payload" do
-      payload = ::QrForge::Payload.build(data: "+1234567890", type: :phone)
+      payload = QrForge::Payload.build(data: "+1234567890", type: :phone)
       expect(payload.to_s).to eq("tel:+1234567890")
     end
 
     it "raises an error for invalid phone number format" do
       expect do
-        ::QrForge::Payload.build(data: "12345", type: :phone)
+        QrForge::Payload.build(data: "12345", type: :phone)
       end.to raise_error(QrForge::Payloads::PayloadValidationError, "Invalid phone number format")
     end
 
     it "does not raise an error for valid phone number" do
       expect do
-        ::QrForge::Payload.build(data: "+1234567890", type: :phone)
-        ::QrForge::Payload.build(data: "1234567890", type: :phone)
-        ::QrForge::Payload.build(data: "123-456-7890", type: :phone)
-        ::QrForge::Payload.build(data: "(123) 456-7890", type: :phone)
-        ::QrForge::Payload.build(data: "123.456.7890", type: :phone)
+        QrForge::Payload.build(data: "+1234567890", type: :phone)
+        QrForge::Payload.build(data: "1234567890", type: :phone)
+        QrForge::Payload.build(data: "123-456-7890", type: :phone)
+        QrForge::Payload.build(data: "(123) 456-7890", type: :phone)
+        QrForge::Payload.build(data: "123.456.7890", type: :phone)
       end.not_to raise_error
     end
   end
 
   context "when geo" do
     it "validates and returns a valid payload" do
-      payload = ::QrForge::Payload.build(data: { latitude: 40.712776, longitude: -74.005974 }, type: :geo)
+      payload = QrForge::Payload.build(data: { latitude: 40.712776, longitude: -74.005974 }, type: :geo)
       expect(payload.to_s).to eq("geo:40.712776,-74.005974")
     end
 
     it "raises an error for invalid latitude" do
       expect do
-        ::QrForge::Payload.build(data: { latitude: 100, longitude: -74.005974 }, type: :geo)
+        QrForge::Payload.build(data: { latitude: 100, longitude: -74.005974 }, type: :geo)
       end.to raise_error(QrForge::Payloads::PayloadValidationError, "Latitude or longitude out of range")
     end
 
     it "raises an error for invalid longitude" do
       expect do
-        ::QrForge::Payload.build(data: { latitude: 40.712776, longitude: 200 }, type: :geo)
+        QrForge::Payload.build(data: { latitude: 40.712776, longitude: 200 }, type: :geo)
       end.to raise_error(QrForge::Payloads::PayloadValidationError, "Latitude or longitude out of range")
     end
 
     it "does not raise an error for valid latitude and longitude" do
       expect do
-        ::QrForge::Payload.build(data: { latitude: 40.712776, longitude: -74.005974 }, type: :geo)
+        QrForge::Payload.build(data: { latitude: 40.712776, longitude: -74.005974 }, type: :geo)
       end.not_to raise_error
     end
   end
 
   context "when url" do
     it "validates and returns a valid payload" do
-      payload = ::QrForge::Payload.build(data: "https://example.com", type: :url)
+      payload = QrForge::Payload.build(data: "https://example.com", type: :url)
       expect(payload.to_s).to eq("https://example.com")
     end
 
     it "raises an error for invalid URL format" do
       expect do
-        ::QrForge::Payload.build(data: "invalid-url", type: :url)
+        QrForge::Payload.build(data: "invalid-url", type: :url)
       end.to raise_error(QrForge::Payloads::PayloadValidationError, "Must be a valid HTTP/HTTPS URL")
     end
 
     it "does not raise an error for valid URL" do
       expect do
-        ::QrForge::Payload.build(data: "http://example.com", type: :url)
-        ::QrForge::Payload.build(data: "https://example.com", type: :url)
+        QrForge::Payload.build(data: "http://example.com", type: :url)
+        QrForge::Payload.build(data: "https://example.com", type: :url)
       end.not_to raise_error
     end
   end
@@ -111,34 +111,34 @@ RSpec.describe QrForge do
   context "when wifi" do
     it "does not raise an error for valid Wi-Fi payload" do
       expect do
-        ::QrForge::Payload.build(data: { ssid: "MyNetwork", password: "MyPassword", encryption: "WPA2" }, type: :wifi)
-        ::QrForge::Payload.build(data: { ssid: "MyNetwork", encryption: "nopass" }, type: :wifi)
+        QrForge::Payload.build(data: { ssid: "MyNetwork", password: "MyPassword", encryption: "WPA2" }, type: :wifi)
+        QrForge::Payload.build(data: { ssid: "MyNetwork", encryption: "nopass" }, type: :wifi)
       end.not_to raise_error
     end
 
     it "validates and returns a valid payload" do
-      payload = ::QrForge::Payload.build(data: { ssid: "MyNetwork", password: "MyPassword", encryption: "WPA" },
-                                         type: :wifi)
+      payload = QrForge::Payload.build(data: { ssid: "MyNetwork", password: "MyPassword", encryption: "WPA" },
+                                       type: :wifi)
       expect(payload.to_s).to eq("WIFI:S:MyNetwork;T:WPA;P:MyPassword;;")
     end
 
     it "raises an error for missing SSID" do
       # This is handled in initialize now as a required keyword argument
       expect do
-        ::QrForge::Payload.build(data: { encryption: "WPA", password: "MyPassword" }, type: :wifi)
+        QrForge::Payload.build(data: { encryption: "WPA", password: "MyPassword" }, type: :wifi)
       end.to raise_error(ArgumentError, "missing keyword: :ssid")
     end
 
     it "raises an error for invalid encryption type" do
       expect do
-        ::QrForge::Payload.build(data: { ssid: "MyNetwork", password: "MyPassword", encryption: "Invalid" },
-                                 type: :wifi)
+        QrForge::Payload.build(data: { ssid: "MyNetwork", password: "MyPassword", encryption: "Invalid" },
+                               type: :wifi)
       end.to raise_error(QrForge::Payloads::PayloadValidationError, "Invalid encryption: INVALID")
     end
 
     it "raises an error for missing password when encryption requires it" do
       expect do
-        ::QrForge::Payload.build(data: { ssid: "MyNetwork", encryption: "WPA" }, type: :wifi)
+        QrForge::Payload.build(data: { ssid: "MyNetwork", encryption: "WPA" }, type: :wifi)
       end.to raise_error(QrForge::Payloads::PayloadValidationError, "Password is required for WPA networks")
     end
   end

--- a/spec/payload_spec.rb
+++ b/spec/payload_spec.rb
@@ -123,9 +123,10 @@ RSpec.describe QrForge do
     end
 
     it "raises an error for missing SSID" do
+      # This is handled in initialize now as a required keyword argument
       expect do
         ::QrForge::Payload.build(data: { encryption: "WPA", password: "MyPassword" }, type: :wifi)
-      end.to raise_error(QrForge::Payloads::PayloadValidationError, "SSID cannot be blank")
+      end.to raise_error(ArgumentError, "missing keyword: :ssid")
     end
 
     it "raises an error for invalid encryption type" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "qr_forge"
-#QrForge.loader.eager_load(force: true)
+# QrForge.loader.eager_load(force: true)
 require "rspec"
 require "capybara"
 require "base64"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,8 @@ require "rspec"
 require "capybara"
 require "base64"
 
+ENV["SVG_OUTPUT_MODE"] = "test"
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"


### PR DESCRIPTION
### PNG Removal

**Reasoning:** 

This gem creates QR codes by creating each element of the code as an SVG element. This leads to perfectly scaling vector graphics and a crystal clear QR Code. However, because this isn't png manipulation (something like ChunkyPNG) it means that when we use something like libvips to convert and rasterize the image where it will lose some fidelity. You can counteract this by increasing the resolution of the image so that when you scale it down later it will retain its crispness. 

Moreover, there are a variety of different image manipulation tools that are out there via Ruby bindings or others, so I think it is best to leave that to the user to decide how they would like to convert IF they would like to convert. In almost all scenarios where you would use this (web, printing, etc.) an SVG is going to be a great option.

I've removed the vips dependency as well as added a cleaning method to remove test_ids from the final output of the svg.